### PR TITLE
new endopints - api keys and org control

### DIFF
--- a/pkg/helpers/query.go
+++ b/pkg/helpers/query.go
@@ -19,6 +19,7 @@ type QueryResponse struct {
 // Interface for the QueryHelper.
 type QueryHelperInterface interface {
 	Get(token string, urlPostfix string, queryParams url.Values) (*QueryResponse, error)
+	Patch(token string, urlPostfix string, queryParams url.Values, bodyParams []byte) (*QueryResponse, error)
 	Post(token string, urlPostfix string, queryParams url.Values, bodyParams []byte) (*QueryResponse, error)
 	Put(token string, urlPostfix string, queryParams url.Values, bodyParams []byte) (*QueryResponse, error)
 	Delete(token string, urlPostfix string, queryParams url.Values) (*QueryResponse, error)
@@ -42,6 +43,12 @@ func (o *QueryHelper) Get(token string, urlPostfix string, queryParams url.Value
 	url := o.assembleURL(urlPostfix, queryParams)
 
 	return o.RequestHelper("GET", token, url, nil)
+}
+
+func (o *QueryHelper) Patch(token string, urlPostfix string, queryParams url.Values, bodyParams []byte) (*QueryResponse, error) {
+	url := o.assembleURL(urlPostfix, queryParams)
+
+	return o.RequestHelper("PATCH", token, url, bodyParams)
 }
 
 func (o *QueryHelper) Post(token string, urlPostfix string, queryParams url.Values, bodyParams []byte) (*QueryResponse, error) {

--- a/pkg/models/api_key.go
+++ b/pkg/models/api_key.go
@@ -1,0 +1,58 @@
+package models
+
+import (
+	"github.com/google/uuid"
+)
+
+// return types
+
+type APIKeyFull struct {
+	APIKeyId         string                 `json:"api_key_id"`
+	CreatedAt        int                    `json:"created_at"`
+	ExpiresAtSeconds int                    `json:"expires_at_seconds"`
+	Metadata         map[string]interface{} `json:"metadata"`
+	UserID           uuid.UUID              `json:"user_id"`
+	OrgID            uuid.UUID              `json:"org_id"`
+}
+
+type APIKeyResultPage struct {
+	APIKeys        []APIKeyFull `json:"api_keys"`
+	TotalAPIKeys   int          `json:"total_api_keys"`
+	CurrentPage    int          `json:"current_page"`
+	PageSize       int          `json:"page_size"`
+	HasMoreResults bool         `json:"has_more_results"`
+}
+
+type APIKeyValidation struct {
+	Metadata      map[string]interface{} `json:"metadata"`
+	UserMetadata  map[string]interface{} `json:"user_metadata"`
+	OrgMetadata   map[string]interface{} `json:"org_metadata"`
+	UserRoleInOrg string                 `json:"user_role_in_org"`
+}
+
+type APIKeyNew struct {
+	APIKeyID    string `json:"api_key_id"`
+	APIKeyToken string `json:"api_key_token"`
+}
+
+// post types
+
+type APIKeysQueryParams struct {
+	OrgID      *uuid.UUID `json:"org_id,omitempty"`
+	UserID     *uuid.UUID `json:"user_id,omitempty"`
+	UserEmail  *string    `json:"user_email,omitempty"`
+	PageSize   *int       `json:"page_size,omitempty"`
+	PageNumber *int       `json:"page_number,omitempty"`
+}
+
+type APIKeyCreateParams struct {
+	OrgID            *uuid.UUID              `json:"org_id,omitempty"`
+	UserID           *uuid.UUID              `json:"user_id,omitempty"`
+	ExpiresAtSeconds *int                    `json:"expires_at_seconds,omitempty"`
+	Metadata         *map[string]interface{} `json:"metadata,omitempty"`
+}
+
+type APIKeyUpdateParams struct {
+	ExpiresAtSeconds *int                    `json:"expires_at_seconds,omitempty"`
+	Metadata         *map[string]interface{} `json:"metadata,omitempty"`
+}

--- a/pkg/models/org.go
+++ b/pkg/models/org.go
@@ -8,8 +8,10 @@ import (
 
 // OrgMetadata has the information about the organziation.
 type OrgMetadata struct {
-	OrgID uuid.UUID `json:"org_id"`
-	Name  string    `json:"name"`
+	OrgID    uuid.UUID              `json:"org_id"`
+	Name     string                 `json:"name"`
+	MaxUsers int                    `json:"max_users"`
+	Metadata map[string]interface{} `json:"metadata"`
 }
 
 // OrgList is a paged list of organizations. The actual fetched organizations are in the Orgs field, and the

--- a/pkg/models/token_data.go
+++ b/pkg/models/token_data.go
@@ -18,11 +18,11 @@ type AccessTokenResponse struct {
 }
 
 type AccessTokenData struct {
-	AccessToken          string                             `json:"access_token"`
-	ExpiresAtSeconds     int64                              `json:"expires_at_seconds"`
+	AccessToken          string                            `json:"access_token"`
+	ExpiresAtSeconds     int64                             `json:"expires_at_seconds"`
 	OrgIDToOrgMemberInfo map[string]OrgMemberInfoFromToken `json:"org_id_to_org_member_info"`
-	User                 UserMetadata                       `json:"user"`
-	ImpersonatorUser     *UserID                            `json:"impersonator_user,omitempty"`
+	User                 UserMetadata                      `json:"user"`
+	ImpersonatorUser     *UserID                           `json:"impersonator_user,omitempty"`
 }
 
 // Models to hold public key data, that is used when initializing the client.
@@ -55,8 +55,8 @@ type UserAndOrgMemberInfoFromToken struct {
 // UserFromToken is the user data from the JWT.
 type UserFromToken struct {
 	UserID               uuid.UUID                          `json:"user_id"`
-	LegacyUserID         *string                             `json:"legacy_user_id,omitempty"`
-	ImpersonatorUserID   *uuid.UUID                          `json:"impersonator_user_id,omitempty"`
+	LegacyUserID         *string                            `json:"legacy_user_id,omitempty"`
+	ImpersonatorUserID   *uuid.UUID                         `json:"impersonator_user_id,omitempty"`
 	Metadata             map[string]interface{}             `json:"metadata,omitempty"`
 	OrgIDToOrgMemberInfo map[string]*OrgMemberInfoFromToken `json:"org_id_to_org_member_info"`
 	jwt.RegisteredClaims

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -14,21 +14,23 @@ type UserID struct {
 
 // UserMetadata is all the information about a specific user.
 type UserMetadata struct {
-	UserID         uuid.UUID              `json:"user_id"`
-	Email          string                 `json:"email"`
-	EmailConfirmed bool                   `json:"email_confirmed"`
-	HasPassword    bool                   `json:"has_password"`
-	Username       *string                `json:"username"`
-	FirstName      *string                `json:"first_name"`
-	LastName       *string                `json:"last_name"`
-	PictureURL     *string                `json:"picture_url"`
-	Locked         bool                   `json:"locked"`
-	Enabled        bool                   `json:"enabled"`
-	MFAEnabled     bool                   `json:"mfa_enabled"`
-	CreatedAt      int64                  `json:"created_at"`
-	LastActiveAt   int64                  `json:"last_active_at"`
-	LegacyUserID   *string                `json:"legacy_user_id"`
-	OrgIDToOrgInfo *map[uuid.UUID]OrgInfo `json:"org_id_to_org_info"`
+	UserID         uuid.UUID               `json:"user_id"`
+	Email          string                  `json:"email"`
+	EmailConfirmed bool                    `json:"email_confirmed"`
+	HasPassword    bool                    `json:"has_password"`
+	Username       *string                 `json:"username"`
+	FirstName      *string                 `json:"first_name"`
+	LastName       *string                 `json:"last_name"`
+	PictureURL     *string                 `json:"picture_url"`
+	Locked         bool                    `json:"locked"`
+	Enabled        bool                    `json:"enabled"`
+	MFAEnabled     bool                    `json:"mfa_enabled"`
+	CanCreateOrgs  bool                    `json:"can_create_org"`
+	CreatedAt      int64                   `json:"created_at"`
+	LastActiveAt   int64                   `json:"last_active_at"`
+	LegacyUserID   *string                 `json:"legacy_user_id"`
+	OrgIDToOrgInfo *map[uuid.UUID]OrgInfo  `json:"org_id_to_org_info"`
+	Metadata       *map[string]interface{} `json:"metadata"`
 }
 
 // OrgInfo is the information about an organization a user is in.
@@ -61,6 +63,7 @@ type CreateUserParams struct {
 	Username                       *string                 `json:"username,omitempty"`
 	FirstName                      *string                 `json:"first_name,omitempty"`
 	LastName                       *string                 `json:"last_name,omitempty"`
+	CanCreateOrgs                  *bool                   `json:"can_create_orgs,omitempty"`
 	Metadata                       *map[string]interface{} `json:"metadata,omitempty"`
 }
 
@@ -94,6 +97,7 @@ type UpdateUserMetadata struct {
 	LastName               *string                 `json:"last_name,omitempty"`
 	PictureURL             *string                 `json:"picture_url,omitempty"`
 	UpdatePasswordRequired *bool                   `json:"update_password_required,omitempty"`
+	CanCreateOrgs          *bool                   `json:"can_create_orgs,omitempty"`
 	Metadata               *map[string]interface{} `json:"metadata,omitempty"`
 }
 


### PR DESCRIPTION
## Set the maximum users in an org

Set the maximum number of users an org can have with the new **MaxUsers** property on the Org object. Set it with the usual UpdateOrg() function, and see the current value with FetchOrg(). It's an optional field, and if it's missing orgs will continue to allow unlimited users.

## Let only certain users create orgs

Users can be given permission to create orgs through **EnableUserCanCreateOrgs()**, and that permission can be removed with **DisableUserCanCreateOrgs()**. This special permission overrides the realm-wide users_can_create_orgs. With this new functionality, you can turn off org creation in general, and only grant certain users the privilege. (If the realm-wide users_can_create_orgs is on, then everyone will always be able to create orgs.)

## API Keys

A whole host of functions for managing API Keys. These aren't the Integration API Keys you use to communicate with PropelAuth (in this very library), these are API Keys that you can give out to your own clients. We'll happily manage them for you. You can set the optional user, an optional org, optional metadata, and an expiration.

These new API Key endpoints are:

- **FetchAPIKey**
- **FetchCurrentAPIKeys**
- **FetchArchivedAPIKeys**
- **CreateAPIKey**
- **UpdateAPIKey**
- **DeleteAPIKey**
- **ValidateAPIKey**