### PR TITLE
Distinguish Personal from Org API Keys

### DIFF
--- a/pkg/models/api_key.go
+++ b/pkg/models/api_key.go
@@ -24,10 +24,22 @@ type APIKeyResultPage struct {
 }
 
 type APIKeyValidation struct {
-	Metadata      map[string]interface{} `json:"metadata"`
-	UserMetadata  map[string]interface{} `json:"user_metadata"`
-	OrgMetadata   map[string]interface{} `json:"org_metadata"`
-	UserRoleInOrg string                 `json:"user_role_in_org"`
+	Metadata  map[string]interface{}  `json:"metadata"`
+	User      *UserMetadata           `json:"user"`
+	Org       *OrgMetadata            `json:"org"`
+	UserInOrg *OrgMemberInfoFromToken `json:"user_in_org"`
+}
+
+type PersonalAPIKeyValidation struct {
+	Metadata map[string]interface{} `json:"metadata"`
+	User     UserMetadata           `json:"user"`
+}
+
+type OrgAPIKeyValidation struct {
+	Metadata  map[string]interface{}  `json:"metadata"`
+	Org       OrgMetadata             `json:"org"`
+	User      *UserMetadata           `json:"user"`
+	UserInOrg *OrgMemberInfoFromToken `json:"user_in_org"`
 }
 
 type APIKeyNew struct {


### PR DESCRIPTION
- user/org metadata are now real types
- role in org is now the full org_member_info so you can do role/perm checks
- two new validation functions for personal/org keys