### PR TITLE
added InviteUserToOrg endpoint

### DIFF
--- a/pkg/client.go
+++ b/pkg/client.go
@@ -50,6 +50,7 @@ type ClientInterface interface {
 
 	// user in org endpoints
 	AddUserToOrg(params models.AddUserToOrg) (bool, error)
+	InviteUserToOrg(params models.InviteUserToOrg) (bool, error)
 	FetchUsersInOrg(orgID uuid.UUID, params models.UserInOrgQueryParams) (*models.UserList, error)
 
 	// api key endpoints
@@ -676,6 +677,28 @@ func (o *Client) AddUserToOrg(params models.AddUserToOrg) (bool, error) {
 
 	if err := o.returnErrorMessageIfNotOk(queryResponse); err != nil {
 		return false, fmt.Errorf("Error on adding user to org: %w", err)
+	}
+
+	return true, nil
+}
+
+// InviteUserToOrg will email a user and invite them to join an org. If they don't have an account
+//  yet, they'll be asked to make one, and will be able to join the org right afterwards.
+func (o *Client) InviteUserToOrg(params models.InviteUserToOrg) (bool, error) {
+	urlPostfix := "invite_user"
+
+	bodyJSON, err := json.Marshal(params)
+	if err != nil {
+		return false, fmt.Errorf("Error on marshalling body params: %w", err)
+	}
+
+	queryResponse, err := o.queryHelper.Post(o.integrationAPIKey, urlPostfix, nil, bodyJSON)
+	if err != nil {
+		return false, fmt.Errorf("Error on inviting user to org: %w", err)
+	}
+
+	if err := o.returnErrorMessageIfNotOk(queryResponse); err != nil {
+		return false, fmt.Errorf("Error on inviting user to org: %w", err)
 	}
 
 	return true, nil

--- a/pkg/models/user_in_org.go
+++ b/pkg/models/user_in_org.go
@@ -23,3 +23,12 @@ type AddUserToOrg struct {
 	OrgID  uuid.UUID `json:"org_id"`
 	Role   string    `json:"role"`
 }
+
+// InviteUserToOrg is the information needed to invite a new user to join an organization. Role is
+// just a string, but it has to match up to one of your defined roles, by default these are Owner,
+// Admin, or Member, but they can be changed via your dashboard.
+type InviteUserToOrg struct {
+	Email string    `json:"email"`
+	OrgID uuid.UUID `json:"org_id"`
+	Role  string    `json:"role"`
+}


### PR DESCRIPTION
You can now invite users to join an organization, and your product, via this nice new endpoint.

This functionality already existed in your frontend, and now it's available on your backend too.

Here's an example of how it works:

```
orgID, err := uuid.Parse("affb4ebb-baa9-4b0e-8d65-4065611d9689")
if err != nil {
    panic(err)
}

newUser := models.InviteUserToOrg{
    Email: "gilgamesh@uruk.com",
    OrgID: orgID,
    Role:  "Admin",
}

_, err = client.InviteUserToOrg(newUser)
if err != nil {
    panic(err)
}
```