### PR TITLE
[TIC-782] Active Org Support

### DIFF
--- a/pkg/client.go
+++ b/pkg/client.go
@@ -1218,10 +1218,9 @@ func (o *Client) CreateAccessToken(userID uuid.UUID, durationInMinutes int, crea
 	// assemble body params
 
 	type CreateAccessToken struct {
-		UserID               uuid.UUID  `json:"user_id"`
-		DurationInMinutes    int        `json:"duration_in_minutes"`
-		ActiveOrgId          *uuid.UUID `json:"active_org_id,omitempty"`
-		WithActiveOrgSupport *bool      `json:"with_active_org_support,omitempty"`
+		UserID            uuid.UUID  `json:"user_id"`
+		DurationInMinutes int        `json:"duration_in_minutes"`
+		ActiveOrgId       *uuid.UUID `json:"active_org_id,omitempty"`
 	}
 
 	bodyParams := CreateAccessToken{
@@ -1231,7 +1230,6 @@ func (o *Client) CreateAccessToken(userID uuid.UUID, durationInMinutes int, crea
 
 	if len(createAccessTokenOptions) == 1 {
 		bodyParams.ActiveOrgId = createAccessTokenOptions[0].ActiveOrgId
-		bodyParams.WithActiveOrgSupport = createAccessTokenOptions[0].WithActiveOrgSupport
 	}
 
 	bodyJSON, err := json.Marshal(bodyParams)

--- a/pkg/client.go
+++ b/pkg/client.go
@@ -20,7 +20,7 @@ const backendURLApiPrefix = "/api/backend/v1/"
 // It's also a convient listing of all the methods available to the integration programmer.
 type ClientInterface interface {
 	// user endpoints
-	CreateAccessToken(userID uuid.UUID, durationInMinutes int, ActiveOrgId *uuid.UUID, WithActiveOrgSupport *bool) (*models.AccessToken, error)
+	CreateAccessToken(userID uuid.UUID, durationInMinutes int, createAccessTokenOptions ...models.CreateAccessTokenOptions) (*models.AccessToken, error)
 	CreateMagicLink(params models.CreateMagicLinkParams) (*models.CreateMagicLinkResponse, error)
 	CreateUser(params models.CreateUserParams) (*models.UserID, error)
 	DeleteUser(userID uuid.UUID) (bool, error)
@@ -1212,7 +1212,7 @@ func (o *Client) ValidateAPIKey(apiKeyToken string) (*models.APIKeyValidation, e
 // public methods for misc functionality
 
 // CreateAccessToken creates an access token.
-func (o *Client) CreateAccessToken(userID uuid.UUID, durationInMinutes int, ActiveOrgId *uuid.UUID, WithActiveOrgSupport *bool) (*models.AccessToken, error) {
+func (o *Client) CreateAccessToken(userID uuid.UUID, durationInMinutes int, createAccessTokenOptions ...models.CreateAccessTokenOptions) (*models.AccessToken, error) {
 	urlPostfix := "access_token"
 
 	// assemble body params
@@ -1229,11 +1229,9 @@ func (o *Client) CreateAccessToken(userID uuid.UUID, durationInMinutes int, Acti
 		DurationInMinutes: durationInMinutes,
 	}
 
-	if ActiveOrgId != nil {
-		bodyParams.ActiveOrgId = ActiveOrgId
-	}
-	if WithActiveOrgSupport != nil {
-		bodyParams.WithActiveOrgSupport = WithActiveOrgSupport
+	if len(createAccessTokenOptions) == 1 {
+		bodyParams.ActiveOrgId = createAccessTokenOptions[0].ActiveOrgId
+		bodyParams.WithActiveOrgSupport = createAccessTokenOptions[0].WithActiveOrgSupport
 	}
 
 	bodyJSON, err := json.Marshal(bodyParams)

--- a/pkg/client.go
+++ b/pkg/client.go
@@ -20,7 +20,7 @@ const backendURLApiPrefix = "/api/backend/v1/"
 // It's also a convient listing of all the methods available to the integration programmer.
 type ClientInterface interface {
 	// user endpoints
-	CreateAccessToken(userID uuid.UUID, durationInMinutes int) (*models.AccessToken, error)
+	CreateAccessToken(userID uuid.UUID, durationInMinutes int, ActiveOrgId *uuid.UUID, WithActiveOrgSupport *bool) (*models.AccessToken, error)
 	CreateMagicLink(params models.CreateMagicLinkParams) (*models.CreateMagicLinkResponse, error)
 	CreateUser(params models.CreateUserParams) (*models.UserID, error)
 	DeleteUser(userID uuid.UUID) (bool, error)
@@ -1212,19 +1212,28 @@ func (o *Client) ValidateAPIKey(apiKeyToken string) (*models.APIKeyValidation, e
 // public methods for misc functionality
 
 // CreateAccessToken creates an access token.
-func (o *Client) CreateAccessToken(userID uuid.UUID, durationInMinutes int) (*models.AccessToken, error) {
+func (o *Client) CreateAccessToken(userID uuid.UUID, durationInMinutes int, ActiveOrgId *uuid.UUID, WithActiveOrgSupport *bool) (*models.AccessToken, error) {
 	urlPostfix := "access_token"
 
 	// assemble body params
 
 	type CreateAccessToken struct {
-		UserID            uuid.UUID `json:"user_id"`
-		DurationInMinutes int       `json:"duration_in_minutes"`
+		UserID               uuid.UUID  `json:"user_id"`
+		DurationInMinutes    int        `json:"duration_in_minutes"`
+		ActiveOrgId          *uuid.UUID `json:"active_org_id,omitempty"`
+		WithActiveOrgSupport *bool      `json:"with_active_org_support,omitempty"`
 	}
 
 	bodyParams := CreateAccessToken{
 		UserID:            userID,
 		DurationInMinutes: durationInMinutes,
+	}
+
+	if ActiveOrgId != nil {
+		bodyParams.ActiveOrgId = ActiveOrgId
+	}
+	if WithActiveOrgSupport != nil {
+		bodyParams.WithActiveOrgSupport = WithActiveOrgSupport
 	}
 
 	bodyJSON, err := json.Marshal(bodyParams)

--- a/pkg/client_test.go
+++ b/pkg/client_test.go
@@ -2,10 +2,11 @@ package client_test
 
 import (
 	"fmt"
+	"testing"
+
 	propelauth "github.com/propelauth/propelauth-go/pkg"
 	"github.com/propelauth/propelauth-go/pkg/models"
 	testHelpers "github.com/propelauth/propelauth-go/pkg/test"
-	"testing"
 )
 
 func TestInitializations(t *testing.T) {
@@ -88,6 +89,38 @@ func TestValidations(t *testing.T) {
 		orgMemberInfo := user.GetOrgMemberInfo(org.OrgID)
 		if orgMemberInfo == nil {
 			t.Errorf("GetOrgMemberInfo should have returned something")
+		}
+	})
+
+	t.Run("GetActiveOrgMemberInfo", func(t *testing.T) {
+		// setup tests
+
+		user, err := client.GetUser(authHeader)
+		if err != nil {
+			t.Errorf("GetUser returned an error: %s", err)
+		}
+
+		// run tests
+		user.ActiveOrgId = &org.OrgID
+		activeOrgMemberInfo := user.GetActiveOrgMemberInfo()
+		if activeOrgMemberInfo == nil {
+			t.Errorf("GetActiveOrgID should have returned something")
+		}
+	})
+
+	t.Run("GetActiveOrgID", func(t *testing.T) {
+		// setup tests
+
+		user, err := client.GetUser(authHeader)
+		if err != nil {
+			t.Errorf("GetUser returned an error: %s", err)
+		}
+
+		// run tests
+		user.ActiveOrgId = &org.OrgID
+		activeOrgID := user.GetActiveOrgID()
+		if activeOrgID == nil {
+			t.Errorf("GetActiveOrgID should have returned something")
 		}
 	})
 

--- a/pkg/models/token_data.go
+++ b/pkg/models/token_data.go
@@ -75,6 +75,19 @@ func (o *UserFromToken) GetOrgMemberInfo(orgID uuid.UUID) *OrgMemberInfoFromToke
 	return o.OrgIDToOrgMemberInfo[orgID.String()]
 }
 
+// GetActiveOrgMemberInfo returns the OrgMemberInfoFromToken for the active Organization.
+func (o *UserFromToken) GetActiveOrgMemberInfo() *OrgMemberInfoFromToken {
+	if o.ActiveOrgId == nil {
+		return nil
+	}
+	return o.GetOrgMemberInfo(*o.ActiveOrgId)
+}
+
+// GetActiveOrgID returns the active Organization UUID.
+func (o *UserFromToken) GetActiveOrgID() *uuid.UUID {
+	return o.ActiveOrgId
+}
+
 // OrgMemberInfoFromToken is data about an organization and about this user's membership in it.
 type OrgMemberInfoFromToken struct {
 	OrgID                             uuid.UUID              `json:"org_id"`

--- a/pkg/models/token_data.go
+++ b/pkg/models/token_data.go
@@ -15,8 +15,7 @@ type AccessToken struct {
 }
 
 type CreateAccessTokenOptions struct {
-	ActiveOrgId          *uuid.UUID
-	WithActiveOrgSupport *bool
+	ActiveOrgId *uuid.UUID
 }
 
 type AccessTokenResponse struct {

--- a/pkg/models/token_data.go
+++ b/pkg/models/token_data.go
@@ -60,6 +60,7 @@ type UserFromToken struct {
 	ImpersonatorUserID   *uuid.UUID                         `json:"impersonator_user_id,omitempty"`
 	OrgIDToOrgMemberInfo map[string]*OrgMemberInfoFromToken `json:"org_id_to_org_member_info"`
 	Metadata             map[string]interface{}             `json:"metadata,omitempty"`
+	OrgMemberInfo        *OrgMemberInfoFromToken            `json:"org_member_info,omitempty"`
 	Email                *string                            `json:"email"`
 	FirstName            *string                            `json:"first_name,omitempty"`
 	LastName             *string                            `json:"last_name,omitempty"`

--- a/pkg/models/token_data.go
+++ b/pkg/models/token_data.go
@@ -14,6 +14,11 @@ type AccessToken struct {
 	AccessToken string `json:"access_token"`
 }
 
+type CreateAccessTokenOptions struct {
+	ActiveOrgId          *uuid.UUID
+	WithActiveOrgSupport *bool
+}
+
 type AccessTokenResponse struct {
 	AccessToken AccessTokenData `json:"access_token"`
 }

--- a/pkg/models/token_data.go
+++ b/pkg/models/token_data.go
@@ -56,6 +56,7 @@ type UserAndOrgMemberInfoFromToken struct {
 // UserFromToken is the user data from the JWT.
 type UserFromToken struct {
 	UserID               uuid.UUID                          `json:"user_id"`
+	ActiveOrgId          *uuid.UUID                         `json:"active_org_id,omitempty"`
 	LegacyUserID         *string                            `json:"legacy_user_id,omitempty"`
 	ImpersonatorUserID   *uuid.UUID                         `json:"impersonator_user_id,omitempty"`
 	OrgIDToOrgMemberInfo map[string]*OrgMemberInfoFromToken `json:"org_id_to_org_member_info"`


### PR DESCRIPTION
https://propelauth.atlassian.net/browse/TIC-782

## Smoke Tests Performed
* In local example app go server, created an access token, called `GetUser`, and then called `GetActiveOrgMemberInfo` and `GetActiveOrgId`.
* Did the above with the following parameters in the `CreateAccessToken`:
-- `ActiveOrgId`: nil -> returns no active org
-- `ActiveOrgId`: "{actual org ID}" -> returns an active org
-- `ActiveOrgId`: "{fake org ID}" -> return an error
-- without any parameters at all (to support backwards compatability)