### PR TITLE
[TIC-794] Add `LoginMethod` to `UserFromToken`

### DIFF
--- a/pkg/models/token_data.go
+++ b/pkg/models/token_data.go
@@ -57,6 +57,12 @@ type UserAndOrgMemberInfoFromToken struct {
 	OrgMemberInfo OrgMemberInfoFromToken
 }
 
+type LoginMethod struct {
+	LoginMethod string `json:"login_method"`
+	Provider    string `json:"provider,omitempty"`
+	OrgID       string `json:"org_id,omitempty"`
+}
+
 // UserFromToken is the user data from the JWT.
 type UserFromToken struct {
 	UserID               uuid.UUID                          `json:"user_id"`
@@ -71,6 +77,7 @@ type UserFromToken struct {
 	LastName             *string                            `json:"last_name,omitempty"`
 	Username             *string                            `json:"username,omitempty"`
 	Properties           map[string]interface{}             `json:"properties,omitempty"`
+	LoginMethod          *LoginMethod                       `json:"login_method,omitempty"`
 	jwt.RegisteredClaims
 }
 


### PR DESCRIPTION
## Smoke Tests
1. With the include_login_method env. config variable disabled, verified that by signing in via social SSO or password, the login method was "unknown".
2. With the include_login_method env. config variable enabled, verified that by signing in via social SSO (github), the login method was "social_sso", with "GitHub" as a provider
3. With the include_login_method env. config variable enabled, verified that by signing in via email/password, the login method was "password"
4. With the include_login_method env. config variable enabled, verified that by creating an access token in the endpoint, the login method was "generated_from_backend_api"
