### PR TITLE
[TIC-902] Add `picture_url` to `MigrateUserParams`

### DIFF
--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -85,6 +85,7 @@ type MigrateUserParams struct {
 	Username                       *string                 `json:"username,omitempty"`
 	FirstName                      *string                 `json:"first_name,omitempty"`
 	LastName                       *string                 `json:"last_name,omitempty"`
+	PictureUrl                     *string                 `json:"picture_url,omitempty"`
 	UpdatePasswordRequired         *bool                   `json:"update_password_required,omitempty"`
 	Properties                     *map[string]interface{} `json:"properties,omitempty"`
 }


### PR DESCRIPTION
# Background
The `picture_url` request parameter was missing from the library. It has now been added as an optional value. 

### Note: This adds a non-backwards compatible change to the `MigrateUserRequest` type for adding `picture_url`.

## Example Usage
```go
import (
	...
	"github.com/propelauth/propelauth-go/pkg/models"
)
apiKey := "API KEY"
authUrl := "AUTH URL"

client, err := propelauth.InitBaseAuth(authUrl, apiKey, nil)
if err != nil {
	panic(err)
}

EmailConfirmed := true
Enabled := true
Username := "testuser2"
FirstName := "Test"
LastName := "User"
Email := "test+2@example.com"
PictureUrl := "https://placekitten.com/200/300"

res, err := client.MigrateUserFromExternalSource(models.MigrateUserParams{
	EmailConfirmed: &EmailConfirmed,
	Enabled:        &Enabled,
	Username:       &Username,
	FirstName:      &FirstName,
	LastName:       &LastName,
	Email:          Email,
	PictureUrl:     &PictureUrl,
})
if err != nil {
	panic(err)
}
```