### PR TITLE
update legacy_org_id, fetch by legacy user/org ids

### DIFF
--- a/pkg/models/org.go
+++ b/pkg/models/org.go
@@ -60,6 +60,7 @@ type UpdateOrg struct {
 	Metadata         *map[string]interface{} `json:"metadata,omitempty"`
 	Domain           *string                 `json:"domain,omitempty"`
 	Require2FABy     *string                 `json:"require_2fa_by,omitempty"`
+	LegacyOrgId      *string                 `json:"legacy_org_id,omitempty"`
 }
 
 // OrgRoleMappingSubscription is the information needed to subscribe an organization to a
@@ -71,10 +72,11 @@ type OrgRoleMappingSubscription struct {
 // OrgQueryParams is the information for querying a pageable organization list. If left blank, PageSize
 // defaults to 10 and PageNumber defaults to 0.
 type OrgQueryParams struct {
-	PageSize   *int    `json:"page_size,omitempty"`
-	PageNumber *int    `json:"page_number,omitempty"`
-	OrderBy    *string `json:"order_by,omitempty"`
-	Name       *string `json:"name,omitempty"`
+	PageSize    *int    `json:"page_size,omitempty"`
+	PageNumber  *int    `json:"page_number,omitempty"`
+	OrderBy     *string `json:"order_by,omitempty"`
+	Name        *string `json:"name,omitempty"`
+	LegacyOrgId *string `json:"legacy_org_id,omitempty"`
 }
 
 // CreateOrgV2Params is the information needed to create an organization, as well as some optional fields.

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -118,6 +118,7 @@ type UserQueryParams struct {
 	OrderBy         *string `json:"order_by,omitempty"`
 	EmailOrUsername *string `json:"email_or_username,omitempty"`
 	IncludeOrgs     *bool   `json:"include_orgs,omitempty"`
+	LegacyUserID	*string `json:"legacy_user_id,omitempty"`
 }
 
 // UpdateUserPasswordParam is the information needed to update a user's password.


### PR DESCRIPTION
[Context](https://www.notion.so/Add-a-legacy-org-ID-542f0ad4647041a3849459e8d352b89c?pvs=4)
[BE PR](https://github.com/PropelAuth/auth/pull/787)

## After PR
1. update org's legacy_org_id
```golang
legacyId := "<LEGACY_ID>"
orgId, _ := uuid.Parse("c19165e3-4c00-4ed2-a321-98d48d4ea890")

auth.UpdateOrgMetadata(
    orgId,
    UpdateOrg{
        LegacyOrgId: &legacyId,
    }
)
```
2. fetch/search orgs on the legacy id (case-sensitive string)
```golang
auth.FetchOrgByQuery(models.OrgQueryParams{
    LegacyOrgId: &legacyId,
})
```
3. fetch/search users on the legacy id (case-sensitive string)
```golang
auth.FetchUsersByQuery(models.UserQueryParams{
    LegacyUserId: &legacyId,
})
```
