### PR TITLE
support configuration of saml connection configuration for an org

### DIFF
--- a/pkg/client.go
+++ b/pkg/client.go
@@ -1175,6 +1175,18 @@ func (o *Client) FetchSamlSpMetadata(orgID uuid.UUID) (*models.SamlSpMetadata, e
 func (o *Client) SetSamlIdpMetadata(params models.SamlIdpMetadata) (bool, error) {
 	urlPostfix := "saml_idp_metadata"
 
+	// check that provider is valid
+	valid_providers := []string{"Google", "Rippling", "OneLogin", "JumpCloud", "Okta", "Azure", "Duo", "Generic"}
+	is_valid_provider := false
+	for _, provider := range valid_providers {
+		if params.Provider == provider {
+			is_valid_provider = true
+		}
+	}
+	if !is_valid_provider {
+		return false, fmt.Errorf("Error on setting SAML IDP Metadata for org: provider must be one of %v", valid_providers)
+	}
+
 	bodyJSON, err := json.Marshal(params)
 	if err != nil {
 		return false, fmt.Errorf("Error on marshalling body params: %w", err)

--- a/pkg/models/org.go
+++ b/pkg/models/org.go
@@ -172,3 +172,17 @@ type CreateSamlConnectionLinkBody struct {
 type CreateSamlConnectionLinkResponse struct {
 	URL string `json:"url"`
 }
+
+type SamlSpMetadata struct {
+	EntityId  string `json:"entity_id"`
+	AcsUrl    string `json:"acs_url"`
+	LogoutUrl string `json:"logout_url"`
+}
+
+type SamlIdpMetadata struct {
+	OrgId 	uuid.UUID `json:"org_id"`
+	IdpEntityId string `json:"idp_entity_id"`
+	IdpSsoUrl string `json:"idp_sso_url"`
+	IdpCertificate string `json:"idp_certificate"`
+	Provider string `json:"provider"`
+}


### PR DESCRIPTION
depends on [BE PR](https://github.com/PropelAuth/auth/pull/844)

## After PR
```golang
org, err := auth.FetchOrg(orgId)

if err != nil {
    w.WriteHeader(500)
    return
}

if !org.IsSamlConfigured {
    fmt.Println("Org does not have SAML configured. Setting up SAML...")

    
    CanSetupSaml := true
    ok, _ := auth.UpdateOrgMetadata(org.OrgID, models.UpdateOrg{CanSetupSaml: &CanSetupSaml})

    if !ok {
	w.WriteHeader(500)
    	return
    }

    spMetadata, err := auth.FetchSamlSpMetadata(org.OrgID)

    if err != nil {
        w.WriteHeader(500)
        return
    }

    fmt.Println("SP Metadata: ", spMetadata)

    // example response...
    // model.SamlSpMetadata{
    //  EntityId: 'https://auth.your.domain/saml/ORGS-URL-SLUG/metadata',
    //  AcsUrl: 'https://auth.your.domain/saml/ORGS-URL-SLUG/acs',
    //  LogoutUrl: 'https://auth.your.domain/saml/ORGS-URL-SLUG/logout'
    // }

    // NOT IMPLEMENTED: Upsert this SP metadata to the IdP
    // NOT IMPLEMENTED: Get the metadata needed from the IdP

    ok, _ = auth.SetSamlIdpMetadata(models.SamlIdpMetadata{
        OrgId: org.OrgID,
        IdpEntityId: "https://sts.windows.net/SOME-UUID/",
        IdpSsoUrl: "https://login.microsoftonline.com/SOME-UUID/saml2",
        IdpCertificate: `-----BEGIN CERTIFICATE-----
MyCertificateHere
-----END CERTIFICATE-----`,
        Provider: "Azure",
    })

    if !ok {
        w.WriteHeader(500)
        return
    }

    ok, _ = auth.SamlGoLive(org.OrgID)

    if !ok {
        w.WriteHeader(500)
        return
    }
} else {
    fmt.Println("Org already has SAML configured. Deleting the connection...")
    ok, _ := auth.DeleteSamlConnection(org.OrgID)

    if !ok {
        w.WriteHeader(500)
        return
    }
}
```

## Tests
Built a modified version of the above proof-of-concept within an example app.