### PR TITLE
add domian search to orgs query

### DIFF
--- a/pkg/models/org.go
+++ b/pkg/models/org.go
@@ -77,6 +77,7 @@ type OrgQueryParams struct {
 	OrderBy     *string `json:"order_by,omitempty"`
 	Name        *string `json:"name,omitempty"`
 	LegacyOrgId *string `json:"legacy_org_id,omitempty"`
+	Domain      *string `json:"domain,omitempty"`
 }
 
 // CreateOrgV2Params is the information needed to create an organization, as well as some optional fields.


### PR DESCRIPTION
[BE PR](https://github.com/PropelAuth/auth/pull/845) dependency

## After PR
You can now:
```golang
domainSearch := "example.com"
auth.FetchOrgByQuery(models.OrgQueryParams{
    Domain: &domainSearch,
})
```
This will only return orgs that have an exact match to the search term w/ either its primary domain or one of its additional domains.
