### PR TITLE
Custom error for rate limiting end-user api keys

### DIFF
--- a/pkg/client.go
+++ b/pkg/client.go
@@ -1460,6 +1460,15 @@ func (o *Client) ValidateAPIKey(apiKeyToken string) (*models.APIKeyValidation, e
 	}
 
 	if err := o.returnErrorMessageIfNotOk(queryResponse); err != nil {
+		if queryResponse.StatusCode == 429 {
+			rateLimitError := &models.ApiKeyRateLimitError{}
+			err = json.Unmarshal(queryResponse.BodyBytes, rateLimitError)
+			if err != nil {
+				return nil, fmt.Errorf("Error on unmarshalling bytes to ApiKeyRateLimitError: %w", err)
+			} else {
+				return nil, rateLimitError
+			}
+		}
 		return nil, fmt.Errorf("Error on validating an API Key: %w", err)
 	}
 

--- a/pkg/models/api_key.go
+++ b/pkg/models/api_key.go
@@ -75,3 +75,13 @@ type APIKeyUpdateParams struct {
 	ExpiresAtSeconds *int                    `json:"expires_at_seconds,omitempty"`
 	Metadata         *map[string]interface{} `json:"metadata,omitempty"`
 }
+
+type ApiKeyRateLimitError struct {
+    WaitSeconds float64 `json:"wait_seconds"`
+	ErrorCode   string  `json:"error_code"`
+	UserFacingError string `json:"user_facing_error"`
+}
+
+func (e *ApiKeyRateLimitError) Error() string {
+    return e.UserFacingError
+}


### PR DESCRIPTION
# After PR
Provides a custom error type `ApiKeyRateLimitError` that's used by `auth.ValidateAPIKey`.

An example usage would be
```go
validation, err := auth.ValidateAPIKey("dhopw42...")
if err != nil {
    var rateLimitError *propelauth.ApiKeyRateLimitError
    if errors.As(err, &rateLimitError) {
        rateLimitYourUsers(rateLimitError.WaitSeconds)
    } else {
        fmt.Println(err)
    }
}
```

Or zooming out, here's a POC handler that takes care of API key auth with some specific handling of rate limit errors:
```go
func requireApiKey(auth propelauth.ClientInterface, next http.HandlerFunc) http.Handler {
	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
		token := r.Header.Get("Authorization")
		if token == "" || !strings.HasPrefix(token, "Bearer ") {
			fmt.Println("No token")
			fmt.Println(token)
			w.WriteHeader(401)
			return
		}
		token = strings.TrimPrefix(token, "Bearer ")

		validation, err := auth.ValidateAPIKey(token)
		if err != nil {
			var rateLimitError *models.ApiKeyRateLimitError
			if errors.As(err, &rateLimitError) {
				message := fmt.Sprintf("You must wait %f seconds before your next request", rateLimitError.WaitSeconds)
				response := MessageResponse{Message: message}
				w.WriteHeader(429)
				json.NewEncoder(w).Encode(response)
				// or
				// http.Error(w, rateLimitError.UserFacingError, 429)
				return
			} else {
				fmt.Println(err)
				w.WriteHeader(401)
				return
			}
		}

		requestContext := context.WithValue(r.Context(), "user", validation.User)
		next.ServeHTTP(w, r.WithContext(requestContext))
	})
}
```

# Tests
Verified the expected behavior in an example app w/ the above.