### PR TITLE
introduce OrgCompleteMetadata with all fields for FetchOrg

### DIFF
--- a/pkg/client.go
+++ b/pkg/client.go
@@ -50,7 +50,7 @@ type ClientInterface interface {
 	CreateOrgV2(params models.CreateOrgV2Params) (*models.CreateOrgV2Response, error)
 	DeleteOrg(orgID uuid.UUID) (bool, error)
 	DisallowOrgToSetupSamlConnection(orgID uuid.UUID) (bool, error)
-	FetchOrg(orgID uuid.UUID) (*models.OrgMetadata, error)
+	FetchOrg(orgID uuid.UUID) (*models.OrgCompleteMetadata, error)
 	FetchOrgByQuery(params models.OrgQueryParams) (*models.OrgList, error)
 	FetchCustomRoleMappings() (*models.CustomRoleMappingList, error)
 	FetchPendingInvites(params models.FetchPendingInvitesParams) (*models.PendingInvitesPage, error)
@@ -850,7 +850,7 @@ func (o *Client) LogoutAllUserSessions(userID uuid.UUID) (bool, error) {
 // public methods for orgs
 
 // FetchOrg will fetch an org's data.
-func (o *Client) FetchOrg(orgID uuid.UUID) (*models.OrgMetadata, error) {
+func (o *Client) FetchOrg(orgID uuid.UUID) (*models.OrgCompleteMetadata, error) {
 	urlPostfix := fmt.Sprintf("org/%s", orgID)
 
 	queryResponse, err := o.queryHelper.Get(o.integrationAPIKey, urlPostfix, nil)
@@ -862,9 +862,9 @@ func (o *Client) FetchOrg(orgID uuid.UUID) (*models.OrgMetadata, error) {
 		return nil, fmt.Errorf("Error on fetching org: %w", err)
 	}
 
-	org := &models.OrgMetadata{}
+	org := &models.OrgCompleteMetadata{}
 	if err := json.Unmarshal(queryResponse.BodyBytes, org); err != nil {
-		return nil, fmt.Errorf("Error on unmarshalling bytes to OrgMetadata: %w", err)
+		return nil, fmt.Errorf("Error on unmarshalling bytes to OrgCompleteMetadata: %w", err)
 	}
 
 	return org, nil

--- a/pkg/models/api_key.go
+++ b/pkg/models/api_key.go
@@ -77,11 +77,11 @@ type APIKeyUpdateParams struct {
 }
 
 type ApiKeyRateLimitError struct {
-    WaitSeconds float64 `json:"wait_seconds"`
-	ErrorCode   string  `json:"error_code"`
-	UserFacingError string `json:"user_facing_error"`
+	WaitSeconds     float64 `json:"wait_seconds"`
+	ErrorCode       string  `json:"error_code"`
+	UserFacingError string  `json:"user_facing_error"`
 }
 
 func (e *ApiKeyRateLimitError) Error() string {
-    return e.UserFacingError
+	return e.UserFacingError
 }

--- a/pkg/models/org.go
+++ b/pkg/models/org.go
@@ -12,14 +12,14 @@ import (
 type OrgCompleteMetadata struct {
 	OrgID                 uuid.UUID              `json:"org_id"`
 	Name                  string                 `json:"org_name"`
-	UrlSafeOrgSlud		  string                 `json:"url_safe_org_slug"`
-	CanSetupSaml		  bool                   `json:"can_setup_saml"`
+	UrlSafeOrgSlud        string                 `json:"url_safe_org_slug"`
+	CanSetupSaml          bool                   `json:"can_setup_saml"`
 	IsSamlConfigured      bool                   `json:"is_saml_configured"`
 	IsSamlInTestMode      bool                   `json:"is_saml_in_test_mode"`
 	Domain                *string                `json:"domain"`
-	ExtraDomains		  []string               `json:"extra_domains"`
-	DomainAutojoin        bool				     `json:"domain_autojoin"`
-	DomainRestrict        bool     		         `json:"domain_restrict"`
+	ExtraDomains          []string               `json:"extra_domains"`
+	DomainAutojoin        bool                   `json:"domain_autojoin"`
+	DomainRestrict        bool                   `json:"domain_restrict"`
 	Metadata              map[string]interface{} `json:"metadata"`
 	MaxUsers              *int                   `json:"max_users"`
 	LegacyOrgId           *string                `json:"legacy_org_id"`
@@ -199,9 +199,9 @@ type SamlSpMetadata struct {
 }
 
 type SamlIdpMetadata struct {
-	OrgId 	uuid.UUID `json:"org_id"`
-	IdpEntityId string `json:"idp_entity_id"`
-	IdpSsoUrl string `json:"idp_sso_url"`
-	IdpCertificate string `json:"idp_certificate"`
-	Provider string `json:"provider"`
+	OrgId          uuid.UUID `json:"org_id"`
+	IdpEntityId    string    `json:"idp_entity_id"`
+	IdpSsoUrl      string    `json:"idp_sso_url"`
+	IdpCertificate string    `json:"idp_certificate"`
+	Provider       string    `json:"provider"`
 }

--- a/pkg/models/org.go
+++ b/pkg/models/org.go
@@ -12,7 +12,7 @@ import (
 type OrgCompleteMetadata struct {
 	OrgID                 uuid.UUID              `json:"org_id"`
 	Name                  string                 `json:"org_name"`
-	UrlSafeOrgSlud        string                 `json:"url_safe_org_slug"`
+	UrlSafeOrgSlug        string                 `json:"url_safe_org_slug"`
 	CanSetupSaml          bool                   `json:"can_setup_saml"`
 	IsSamlConfigured      bool                   `json:"is_saml_configured"`
 	IsSamlInTestMode      bool                   `json:"is_saml_in_test_mode"`

--- a/pkg/models/org.go
+++ b/pkg/models/org.go
@@ -9,14 +9,32 @@ import (
 // return types
 
 // OrgMetadata has the information about the organziation.
+type OrgCompleteMetadata struct {
+	OrgID                 uuid.UUID              `json:"org_id"`
+	Name                  string                 `json:"org_name"`
+	UrlSafeOrgSlud		  string                 `json:"url_safe_org_slug"`
+	CanSetupSaml		  bool                   `json:"can_setup_saml"`
+	IsSamlConfigured      bool                   `json:"is_saml_configured"`
+	IsSamlInTestMode      bool                   `json:"is_saml_in_test_mode"`
+	Domain                *string                `json:"domain"`
+	ExtraDomains		  []string               `json:"extra_domains"`
+	DomainAutojoin        bool				     `json:"domain_autojoin"`
+	DomainRestrict        bool     		         `json:"domain_restrict"`
+	Metadata              map[string]interface{} `json:"metadata"`
+	MaxUsers              *int                   `json:"max_users"`
+	LegacyOrgId           *string                `json:"legacy_org_id"`
+	CustomRoleMappingName string                 `json:"custom_role_mapping_name"`
+}
+
+// OrgMetadata has the information about the organziation.
 type OrgMetadata struct {
 	OrgID                 uuid.UUID              `json:"org_id"`
 	Name                  string                 `json:"org_name"`
 	MaxUsers              *int                   `json:"max_users"`
 	Metadata              map[string]interface{} `json:"metadata"`
 	IsSamlConfigured      bool                   `json:"is_saml_configured"`
-	CustomRoleMappingName *string                `json:"custom_role_mapping_name"`
-	LegacyOrgId           string                 `json:"legacy_org_id"`
+	LegacyOrgId           *string                `json:"legacy_org_id"`
+	CustomRoleMappingName string                 `json:"custom_role_mapping_name"`
 }
 
 // OrgList is a paged list of organizations. The actual fetched organizations are in the Orgs field, and the

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -118,7 +118,7 @@ type UserQueryParams struct {
 	OrderBy         *string `json:"order_by,omitempty"`
 	EmailOrUsername *string `json:"email_or_username,omitempty"`
 	IncludeOrgs     *bool   `json:"include_orgs,omitempty"`
-	LegacyUserID	*string `json:"legacy_user_id,omitempty"`
+	LegacyUserID    *string `json:"legacy_user_id,omitempty"`
 }
 
 // UpdateUserPasswordParam is the information needed to update a user's password.

--- a/pkg/models/user_in_org.go
+++ b/pkg/models/user_in_org.go
@@ -22,10 +22,10 @@ type UserInOrgQueryParams struct {
 // they can be changed via your dashboard. If you've configured multiple roles per user in your project,
 // you can also include additional_roles to add multiple roles to a user in an organization.
 type AddUserToOrg struct {
-	UserID uuid.UUID `json:"user_id"`
-	OrgID  uuid.UUID `json:"org_id"`
-	Role   string    `json:"role"`
-	AdditionalRoles []string `json:"additional_roles,omitempty"`
+	UserID          uuid.UUID `json:"user_id"`
+	OrgID           uuid.UUID `json:"org_id"`
+	Role            string    `json:"role"`
+	AdditionalRoles []string  `json:"additional_roles,omitempty"`
 }
 
 // RemoveUserFromOrg is the information needed to remove a user from an organization.
@@ -39,10 +39,10 @@ type RemoveUserFromOrg struct {
 // Admin, or Member, but they can be changed via your dashboard. If you've configured multiple roles per user in your project,
 // you can also include additional_roles to add multiple roles to a user in an organization.
 type InviteUserToOrg struct {
-	Email string    `json:"email"`
-	OrgID uuid.UUID `json:"org_id"`
-	Role  string    `json:"role"`
-	AdditionalRoles []string `json:"additional_roles,omitempty"`
+	Email           string    `json:"email"`
+	OrgID           uuid.UUID `json:"org_id"`
+	Role            string    `json:"role"`
+	AdditionalRoles []string  `json:"additional_roles,omitempty"`
 }
 
 // ChangeUserRoleInOrg is the information needed to change a user's role in an organization. Role is
@@ -50,8 +50,8 @@ type InviteUserToOrg struct {
 // Admin, or Member, but they can be changed via your dashboard. If you've configured multiple roles per user in your project,
 // you can also include additional_roles to add multiple roles to a user in an organization.
 type ChangeUserRoleInOrg struct {
-	UserID uuid.UUID `json:"user_id"`
-	OrgID  uuid.UUID `json:"org_id"`
-	Role   string    `json:"role"`
-	AdditionalRoles []string `json:"additional_roles,omitempty"`
+	UserID          uuid.UUID `json:"user_id"`
+	OrgID           uuid.UUID `json:"org_id"`
+	Role            string    `json:"role"`
+	AdditionalRoles []string  `json:"additional_roles,omitempty"`
 }

--- a/pkg/test/helpers.go
+++ b/pkg/test/helpers.go
@@ -27,7 +27,7 @@ func RandomOrg(userRole string, multi_role bool) models.OrgMemberInfoFromToken {
 			OrgID:                             RandomOrgID(),
 			OrgName:                           "orgname",
 			OrgMetadata:                       map[string]interface{}{},
-			OrgRoleStructure: 				   models.MultiRole,
+			OrgRoleStructure:                  models.MultiRole,
 			UserAssignedRole:                  userRole,
 			UserInheritedRolesPlusCurrentRole: []string{userRole},
 		}


### PR DESCRIPTION
## After PR
This introduces the new `OrgCompleteMetadata` response type used by `FetchOrg` disentangling its return type from the `CreateOrg` and `FetchOrgByQuery` functions which don't receive as detailed data from the BE. This isn't an entirely back-compat change for some users unfortunately (ie if they make explicit reference to the current return type).

## Docs
Response [here](https://docs.propelauth.com/reference/api/org#fetch-org) will now look like:
```
OrgCompleteMetadata{
    OrgID:    uuid.MustParse("1189c444-8a2d-4c41-8b4b-ae43ce79a492"),
    Name:     "Acme Inc",
    MaxUsers: 0,
    CustomRoleMappingName: "Paid Plan",
    LegacyOrgId: "1234",
    Custom
    Metadata: map[string]interface{}{
        "customKey": "customValue",
    },
    UrlSafeOrgSlug: "236134a3-ee4f-44d2-8c6c-a0d9d75126fd",
    CanSetupSaml: false,
    IsSamlConfigured: false,
    IsSamlInTestMode: false,
    Domain: nil | "www.org-domain.com",
    ExtraDomains: ["another.org-domain-com"],
    DomainAutojoin: false,
    DomainRestrict: false
}
```


## Tests
Smoke tested w/ an example app that used both `auth.FetchOrg` and `auth.FetchOrgByQuery` and verified the types and data were as expected.