### PR TITLE
support fetching user insights reports

### DIFF
--- a/pkg/client.go
+++ b/pkg/client.go
@@ -1998,7 +1998,7 @@ func (o *Client) FetchEmployeeByID(employeeID uuid.UUID) (*models.FetchEmployeeB
 
 // methods to fetch user insights report data
 
-// FetchUserTopInviterReport will fetch the latest report on which users are the 
+// FetchUserTopInviterReport will fetch the latest report on which users are the
 // most frequent inviters. Default pagination is page size of 10 and page number 0.
 // Valid reportInterval values include "30", "60", and "90" for 30/60/90 days respectively.
 // Default reportInterval is 30 days.
@@ -2039,7 +2039,7 @@ func (o *Client) FetchUserTopInviterReport(reportInterval *string, pagination *m
 	return report, nil
 }
 
-// FetchUserChampionReport will fetch the latest report on which users are champions. 
+// FetchUserChampionReport will fetch the latest report on which users are champions.
 // Default pagination is page size of 10 and page number of 0.
 // Valid reportInterval values include "30", "60", and "90" for 30/60/90 days respectively.
 // Default reportInterval is 30 days.
@@ -2080,7 +2080,7 @@ func (o *Client) FetchUserChampionReport(reportInterval *string, pagination *mod
 	return report, nil
 }
 
-// FetchUserChurnReport will fetch the latest report on which users have churned. 
+// FetchUserChurnReport will fetch the latest report on which users have churned.
 // Default pagination is page size of 10 and page number of 0.
 // Valid reportInterval values include "7", "14", and "30" for 7/14/30 days respectively.
 // Default reportInterval is 7 days.
@@ -2202,7 +2202,7 @@ func (o *Client) FetchOrgGrowthReport(reportInterval *string, pagination *models
 	return report, nil
 }
 
-// FetchOrgAttritionReport will fetch the latest report on which orgs have the most attrition. 
+// FetchOrgAttritionReport will fetch the latest report on which orgs have the most attrition.
 // Default pagination is page size of 10 and page number of 0.
 // Valid reportInterval values include "30", "60", and "90" for 30/60/90 days respectively.
 // Default reportInterval is 30 days.
@@ -2243,7 +2243,7 @@ func (o *Client) FetchOrgAttritionReport(reportInterval *string, pagination *mod
 	return report, nil
 }
 
-// FetchOrgChurnReport will fetch the latest report on which orgs have churned. 
+// FetchOrgChurnReport will fetch the latest report on which orgs have churned.
 // Default pagination is page size of 10 and page number of 0.
 // Valid reportInterval values include "7", "14", and "30" for 7/14/30 days respectively.
 // Default reportInterval is 7 days.
@@ -2284,7 +2284,7 @@ func (o *Client) FetchOrgChurnReport(reportInterval *string, pagination *models.
 	return report, nil
 }
 
-// FetchOrgReengagementReport will fetch the latest report on which orgs have reengaged. 
+// FetchOrgReengagementReport will fetch the latest report on which orgs have reengaged.
 // Default pagination is page size of 10 and page number of 0.
 // Valid reportInterval values include "Weekly" or "Monthly". Default reportInterval is Weekly.
 func (o *Client) FetchOrgReengagementReport(reportInterval *string, pagination *models.ReportPagination) (*models.OrgReport, error) {
@@ -2323,7 +2323,6 @@ func (o *Client) FetchOrgReengagementReport(reportInterval *string, pagination *
 
 	return report, nil
 }
-
 
 // public methods around authorization
 

--- a/pkg/client.go
+++ b/pkg/client.go
@@ -2324,6 +2324,58 @@ func (o *Client) FetchOrgReengagementReport(reportInterval *string, pagination *
 	return report, nil
 }
 
+// FetchChartMetricData will fetch the chart metric data for the specified cadence and interval.
+// Valid `cadence` values include "Daily", "Weekly", or "Monthly". Default cadence is Daily.
+// Default startDate is 30 days ago. Default endDate is today.
+func (o *Client) FetchChartMetricData(chartMetric string, cadence *string, chartRange *models.ChartRange) (*models.ChartData, error) {
+	validChartMetrics := []string{"signups", "orgs_created", "active_orgs", "active_users"}
+	if !slices.Contains(validChartMetrics, chartMetric) {
+		return nil, fmt.Errorf("Only `signups`, `orgs_created`, `active_orgs`, or `active_users` are valid values for chartMetric")
+	}
+	urlPostfix := fmt.Sprintf("chart_metrics/%s", chartMetric)
+
+	queryParams := url.Values{}
+
+	if chartRange != nil {
+		if chartRange.StartDate != nil {
+			if !o.validationHelper.IsValidIsoDate(*chartRange.StartDate) {
+				return nil, fmt.Errorf("startDate must be in the format YYYY-MM-DD")
+			}
+			queryParams.Add("start_date", *chartRange.StartDate)
+		}
+		if chartRange.EndDate != nil {
+			if !o.validationHelper.IsValidIsoDate(*chartRange.EndDate) {
+				return nil, fmt.Errorf("endDate must be in the format YYYY-MM-DD")
+			}
+			queryParams.Add("end_date", *chartRange.EndDate)
+		}
+	}
+
+	if cadence != nil {
+		validCadences := []string{"Daily", "Weekly", "Monthly"}
+		if !slices.Contains(validCadences, *cadence) {
+			return nil, fmt.Errorf("Only `Daily`, `Weekly`, or `Monthly` are valid values for cadence")
+		}
+		queryParams.Add("cadence", *cadence)
+	}
+
+	queryResponse, err := o.queryHelper.Get(o.integrationAPIKey, urlPostfix, queryParams)
+	if err != nil {
+		return nil, fmt.Errorf("Error on fetching chart data: %w", err)
+	}
+
+	if err := o.returnErrorMessageIfNotOk(queryResponse); err != nil {
+		return nil, fmt.Errorf("Error on fetching chart data: %w", err)
+	}
+
+	chartData := &models.ChartData{}
+	if err := json.Unmarshal(queryResponse.BodyBytes, chartData); err != nil {
+		return nil, fmt.Errorf("Error on unmarshalling bytes to ChartData: %w", err)
+	}
+
+	return chartData, nil
+}
+
 // public methods around authorization
 
 // GetUser will get a user from a JWT token. From there you get orgs the user is in, and validate the user's

--- a/pkg/client.go
+++ b/pkg/client.go
@@ -97,6 +97,17 @@ type ClientInterface interface {
 	ImportAPIKey(params models.APIKeyImportParams) (*models.APIKeyImportedNew, error)
 	ValidateImportedAPIKey(apiKeyToken string) (*models.APIKeyValidation, error)
 
+	// user insights endpoints
+	FetchUserTopInviterReport(reportInterval *string, pagination *models.ReportPagination) (*models.UserReport, error)
+	FetchUserChampionReport(reportInterval *string, pagination *models.ReportPagination) (*models.UserReport, error)
+	FetchUserChurnReport(reportInterval *string, pagination *models.ReportPagination) (*models.UserReport, error)
+	FetchUserReengagementReport(reportInterval *string, pagination *models.ReportPagination) (*models.UserReport, error)
+	FetchOrgGrowthReport(reportInterval *string, pagination *models.ReportPagination) (*models.OrgReport, error)
+	FetchOrgAttritionReport(reportInterval *string, pagination *models.ReportPagination) (*models.OrgReport, error)
+	FetchOrgChurnReport(reportInterval *string, pagination *models.ReportPagination) (*models.OrgReport, error)
+	FetchOrgReengagementReport(reportInterval *string, pagination *models.ReportPagination) (*models.OrgReport, error)
+	FetchChartMetricData(chartMetric string, cadence *string, chartRange *models.ChartRange) (*models.ChartData, error)
+
 	// a method to validate the JWT
 	GetUser(authHeader string) (*models.UserFromToken, error)
 }

--- a/pkg/client.go
+++ b/pkg/client.go
@@ -2327,6 +2327,7 @@ func (o *Client) FetchOrgReengagementReport(reportInterval *string, pagination *
 // FetchChartMetricData will fetch the chart metric data for the specified cadence and interval.
 // Valid `cadence` values include "Daily", "Weekly", or "Monthly". Default cadence is Daily.
 // Default startDate is 30 days ago. Default endDate is today.
+// Valid `chartMetric` values include "signups", "orgs_created", "active_orgs", or "active_users".
 func (o *Client) FetchChartMetricData(chartMetric string, cadence *string, chartRange *models.ChartRange) (*models.ChartData, error) {
 	validChartMetrics := []string{"signups", "orgs_created", "active_orgs", "active_users"}
 	if !slices.Contains(validChartMetrics, chartMetric) {

--- a/pkg/client.go
+++ b/pkg/client.go
@@ -3,6 +3,7 @@ package client
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 
 	"encoding/json"
@@ -1994,6 +1995,335 @@ func (o *Client) FetchEmployeeByID(employeeID uuid.UUID) (*models.FetchEmployeeB
 
 	return employee, nil
 }
+
+// methods to fetch user insights report data
+
+// FetchUserTopInviterReport will fetch the latest report on which users are the 
+// most frequent inviters. Default pagination is page size of 10 and page number 0.
+// Valid reportInterval values include "30", "60", and "90" for 30/60/90 days respectively.
+// Default reportInterval is 30 days.
+func (o *Client) FetchUserTopInviterReport(reportInterval *string, pagination *models.ReportPagination) (*models.UserReport, error) {
+	queryParams := url.Values{}
+
+	if pagination != nil {
+		if pagination.PageSize != nil {
+			queryParams.Add("page_size", strconv.Itoa(*pagination.PageSize))
+		}
+		if pagination.PageNumber != nil {
+			queryParams.Add("page_number", strconv.Itoa(*pagination.PageNumber))
+		}
+	}
+
+	if reportInterval != nil {
+		validReportIntervals := []string{"30", "60", "90"}
+		if !slices.Contains(validReportIntervals, *reportInterval) {
+			return nil, fmt.Errorf("Only `30`, `60`, or `90` are valid values for reportInterval")
+		}
+		queryParams.Add("report_interval", *reportInterval)
+	}
+
+	queryResponse, err := o.queryHelper.Get(o.integrationAPIKey, "user_report/top_inviter", queryParams)
+	if err != nil {
+		return nil, fmt.Errorf("Error on fetching report: %w", err)
+	}
+
+	if err := o.returnErrorMessageIfNotOk(queryResponse); err != nil {
+		return nil, fmt.Errorf("Error on fetching report: %w", err)
+	}
+
+	report := &models.UserReport{}
+	if err := json.Unmarshal(queryResponse.BodyBytes, report); err != nil {
+		return nil, fmt.Errorf("Error on unmarshalling bytes to UserReport: %w", err)
+	}
+
+	return report, nil
+}
+
+// FetchUserChampionReport will fetch the latest report on which users are champions. 
+// Default pagination is page size of 10 and page number of 0.
+// Valid reportInterval values include "30", "60", and "90" for 30/60/90 days respectively.
+// Default reportInterval is 30 days.
+func (o *Client) FetchUserChampionReport(reportInterval *string, pagination *models.ReportPagination) (*models.UserReport, error) {
+	queryParams := url.Values{}
+
+	if pagination != nil {
+		if pagination.PageSize != nil {
+			queryParams.Add("page_size", strconv.Itoa(*pagination.PageSize))
+		}
+		if pagination.PageNumber != nil {
+			queryParams.Add("page_number", strconv.Itoa(*pagination.PageNumber))
+		}
+	}
+
+	if reportInterval != nil {
+		validReportIntervals := []string{"30", "60", "90"}
+		if !slices.Contains(validReportIntervals, *reportInterval) {
+			return nil, fmt.Errorf("Only `30`, `60`, or `90` are valid values for reportInterval")
+		}
+		queryParams.Add("report_interval", *reportInterval)
+	}
+
+	queryResponse, err := o.queryHelper.Get(o.integrationAPIKey, "user_report/champion", queryParams)
+	if err != nil {
+		return nil, fmt.Errorf("Error on fetching report: %w", err)
+	}
+
+	if err := o.returnErrorMessageIfNotOk(queryResponse); err != nil {
+		return nil, fmt.Errorf("Error on fetching report: %w", err)
+	}
+
+	report := &models.UserReport{}
+	if err := json.Unmarshal(queryResponse.BodyBytes, report); err != nil {
+		return nil, fmt.Errorf("Error on unmarshalling bytes to UserReport: %w", err)
+	}
+
+	return report, nil
+}
+
+// FetchUserChurnReport will fetch the latest report on which users have churned. 
+// Default pagination is page size of 10 and page number of 0.
+// Valid reportInterval values include "7", "14", and "30" for 7/14/30 days respectively.
+// Default reportInterval is 7 days.
+func (o *Client) FetchUserChurnReport(reportInterval *string, pagination *models.ReportPagination) (*models.UserReport, error) {
+	queryParams := url.Values{}
+
+	if pagination != nil {
+		if pagination.PageSize != nil {
+			queryParams.Add("page_size", strconv.Itoa(*pagination.PageSize))
+		}
+		if pagination.PageNumber != nil {
+			queryParams.Add("page_number", strconv.Itoa(*pagination.PageNumber))
+		}
+	}
+
+	if reportInterval != nil {
+		validReportIntervals := []string{"7", "14", "30"}
+		if !slices.Contains(validReportIntervals, *reportInterval) {
+			return nil, fmt.Errorf("Only `7`, `14`, or `30` are valid values for reportInterval")
+		}
+		queryParams.Add("report_interval", *reportInterval)
+	}
+
+	queryResponse, err := o.queryHelper.Get(o.integrationAPIKey, "user_report/churn", queryParams)
+	if err != nil {
+		return nil, fmt.Errorf("Error on fetching report: %w", err)
+	}
+
+	if err := o.returnErrorMessageIfNotOk(queryResponse); err != nil {
+		return nil, fmt.Errorf("Error on fetching report: %w", err)
+	}
+
+	report := &models.UserReport{}
+	if err := json.Unmarshal(queryResponse.BodyBytes, report); err != nil {
+		return nil, fmt.Errorf("Error on unmarshalling bytes to UserReport: %w", err)
+	}
+
+	return report, nil
+}
+
+// FetchUserReengagementReport will fetch the latest report on which users have reengaged.
+// Default pagination is page size of 10 and page number of 0.
+// Valid reportInterval values include "Weekly" or "Monthly". Default reportInterval is Weekly.
+func (o *Client) FetchUserReengagementReport(reportInterval *string, pagination *models.ReportPagination) (*models.UserReport, error) {
+	queryParams := url.Values{}
+
+	if pagination != nil {
+		if pagination.PageSize != nil {
+			queryParams.Add("page_size", strconv.Itoa(*pagination.PageSize))
+		}
+		if pagination.PageNumber != nil {
+			queryParams.Add("page_number", strconv.Itoa(*pagination.PageNumber))
+		}
+	}
+
+	if reportInterval != nil {
+		validReportIntervals := []string{"Weekly", "Monthly"}
+		if !slices.Contains(validReportIntervals, *reportInterval) {
+			return nil, fmt.Errorf("Only `Weekly` or `Monthly` are valid values for reportInterval")
+		}
+		queryParams.Add("report_interval", *reportInterval)
+	}
+
+	queryResponse, err := o.queryHelper.Get(o.integrationAPIKey, "user_report/reengagement", queryParams)
+	if err != nil {
+		return nil, fmt.Errorf("Error on fetching report: %w", err)
+	}
+
+	if err := o.returnErrorMessageIfNotOk(queryResponse); err != nil {
+		return nil, fmt.Errorf("Error on fetching report: %w", err)
+	}
+
+	report := &models.UserReport{}
+	if err := json.Unmarshal(queryResponse.BodyBytes, report); err != nil {
+		return nil, fmt.Errorf("Error on unmarshalling bytes to UserReport: %w", err)
+	}
+
+	return report, nil
+}
+
+// FetchOrgGrowthReport will fetch the latest report on which orgs have grown most.
+// Default pagination is page size of 10 and page number 0.
+// Valid reportInterval values include "30", "60", and "90" for 30/60/90 days respectively.
+// Default reportInterval is 30 days.
+func (o *Client) FetchOrgGrowthReport(reportInterval *string, pagination *models.ReportPagination) (*models.OrgReport, error) {
+	queryParams := url.Values{}
+
+	if pagination != nil {
+		if pagination.PageSize != nil {
+			queryParams.Add("page_size", strconv.Itoa(*pagination.PageSize))
+		}
+		if pagination.PageNumber != nil {
+			queryParams.Add("page_number", strconv.Itoa(*pagination.PageNumber))
+		}
+	}
+
+	if reportInterval != nil {
+		validReportIntervals := []string{"30", "60", "90"}
+		if !slices.Contains(validReportIntervals, *reportInterval) {
+			return nil, fmt.Errorf("Only `30`, `60`, or `90` are valid values for reportInterval")
+		}
+		queryParams.Add("report_interval", *reportInterval)
+	}
+
+	queryResponse, err := o.queryHelper.Get(o.integrationAPIKey, "org_report/growth", queryParams)
+	if err != nil {
+		return nil, fmt.Errorf("Error on fetching report: %w", err)
+	}
+
+	if err := o.returnErrorMessageIfNotOk(queryResponse); err != nil {
+		return nil, fmt.Errorf("Error on fetching report: %w", err)
+	}
+
+	report := &models.OrgReport{}
+	if err := json.Unmarshal(queryResponse.BodyBytes, report); err != nil {
+		return nil, fmt.Errorf("Error on unmarshalling bytes to OrgReport: %w", err)
+	}
+
+	return report, nil
+}
+
+// FetchOrgAttritionReport will fetch the latest report on which orgs have the most attrition. 
+// Default pagination is page size of 10 and page number of 0.
+// Valid reportInterval values include "30", "60", and "90" for 30/60/90 days respectively.
+// Default reportInterval is 30 days.
+func (o *Client) FetchOrgAttritionReport(reportInterval *string, pagination *models.ReportPagination) (*models.OrgReport, error) {
+	queryParams := url.Values{}
+
+	if pagination != nil {
+		if pagination.PageSize != nil {
+			queryParams.Add("page_size", strconv.Itoa(*pagination.PageSize))
+		}
+		if pagination.PageNumber != nil {
+			queryParams.Add("page_number", strconv.Itoa(*pagination.PageNumber))
+		}
+	}
+
+	if reportInterval != nil {
+		validReportIntervals := []string{"30", "60", "90"}
+		if !slices.Contains(validReportIntervals, *reportInterval) {
+			return nil, fmt.Errorf("Only `30`, `60`, or `90` are valid values for reportInterval")
+		}
+		queryParams.Add("report_interval", *reportInterval)
+	}
+
+	queryResponse, err := o.queryHelper.Get(o.integrationAPIKey, "org_report/attrition", queryParams)
+	if err != nil {
+		return nil, fmt.Errorf("Error on fetching report: %w", err)
+	}
+
+	if err := o.returnErrorMessageIfNotOk(queryResponse); err != nil {
+		return nil, fmt.Errorf("Error on fetching report: %w", err)
+	}
+
+	report := &models.OrgReport{}
+	if err := json.Unmarshal(queryResponse.BodyBytes, report); err != nil {
+		return nil, fmt.Errorf("Error on unmarshalling bytes to OrgReport: %w", err)
+	}
+
+	return report, nil
+}
+
+// FetchOrgChurnReport will fetch the latest report on which orgs have churned. 
+// Default pagination is page size of 10 and page number of 0.
+// Valid reportInterval values include "7", "14", and "30" for 7/14/30 days respectively.
+// Default reportInterval is 7 days.
+func (o *Client) FetchOrgChurnReport(reportInterval *string, pagination *models.ReportPagination) (*models.OrgReport, error) {
+	queryParams := url.Values{}
+
+	if pagination != nil {
+		if pagination.PageSize != nil {
+			queryParams.Add("page_size", strconv.Itoa(*pagination.PageSize))
+		}
+		if pagination.PageNumber != nil {
+			queryParams.Add("page_number", strconv.Itoa(*pagination.PageNumber))
+		}
+	}
+
+	if reportInterval != nil {
+		validReportIntervals := []string{"7", "14", "30"}
+		if !slices.Contains(validReportIntervals, *reportInterval) {
+			return nil, fmt.Errorf("Only `7`, `14`, or `30` are valid values for reportInterval")
+		}
+		queryParams.Add("report_interval", *reportInterval)
+	}
+
+	queryResponse, err := o.queryHelper.Get(o.integrationAPIKey, "org_report/churn", queryParams)
+	if err != nil {
+		return nil, fmt.Errorf("Error on fetching report: %w", err)
+	}
+
+	if err := o.returnErrorMessageIfNotOk(queryResponse); err != nil {
+		return nil, fmt.Errorf("Error on fetching report: %w", err)
+	}
+
+	report := &models.OrgReport{}
+	if err := json.Unmarshal(queryResponse.BodyBytes, report); err != nil {
+		return nil, fmt.Errorf("Error on unmarshalling bytes to OrgReport: %w", err)
+	}
+
+	return report, nil
+}
+
+// FetchOrgReengagementReport will fetch the latest report on which orgs have reengaged. 
+// Default pagination is page size of 10 and page number of 0.
+// Valid reportInterval values include "Weekly" or "Monthly". Default reportInterval is Weekly.
+func (o *Client) FetchOrgReengagementReport(reportInterval *string, pagination *models.ReportPagination) (*models.OrgReport, error) {
+	queryParams := url.Values{}
+
+	if pagination != nil {
+		if pagination.PageSize != nil {
+			queryParams.Add("page_size", strconv.Itoa(*pagination.PageSize))
+		}
+		if pagination.PageNumber != nil {
+			queryParams.Add("page_number", strconv.Itoa(*pagination.PageNumber))
+		}
+	}
+
+	if reportInterval != nil {
+		validReportIntervals := []string{"Weekly", "Monthly"}
+		if !slices.Contains(validReportIntervals, *reportInterval) {
+			return nil, fmt.Errorf("Only `Weekly` or `Monthly` are valid values for reportInterval")
+		}
+		queryParams.Add("report_interval", *reportInterval)
+	}
+
+	queryResponse, err := o.queryHelper.Get(o.integrationAPIKey, "org_report/reengagement", queryParams)
+	if err != nil {
+		return nil, fmt.Errorf("Error on fetching report: %w", err)
+	}
+
+	if err := o.returnErrorMessageIfNotOk(queryResponse); err != nil {
+		return nil, fmt.Errorf("Error on fetching report: %w", err)
+	}
+
+	report := &models.OrgReport{}
+	if err := json.Unmarshal(queryResponse.BodyBytes, report); err != nil {
+		return nil, fmt.Errorf("Error on unmarshalling bytes to OrgReport: %w", err)
+	}
+
+	return report, nil
+}
+
 
 // public methods around authorization
 

--- a/pkg/helpers/validation.go
+++ b/pkg/helpers/validation.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	jwt "github.com/golang-jwt/jwt/v5"
 	models "github.com/propelauth/propelauth-go/pkg/models"
@@ -17,6 +18,7 @@ type ValidationHelperInterface interface {
 	ValidateAccessTokenAndGetUser(accessToken string, tokenVerificationMetadata models.TokenVerificationMetadata) (*models.UserFromToken, error)
 	ExtractTokenFromAuthorizationHeader(authHeader string) (string, error)
 	ConvertPEMStringToRSAPublicKey(pemString string) (*rsa.PublicKey, error)
+	IsValidIsoDate(dateStr string) bool
 }
 
 type ValidationHelper struct{}
@@ -116,4 +118,9 @@ func (o *ValidationHelper) ConvertPEMStringToRSAPublicKey(pemString string) (*rs
 	}
 
 	return nil, fmt.Errorf("Error when parsing public key: %w", err)
+}
+
+func (o *ValidationHelper) IsValidIsoDate(dateStr string) bool {
+	_, err := time.Parse(time.DateOnly, dateStr)
+	return err == nil
 }

--- a/pkg/models/report.go
+++ b/pkg/models/report.go
@@ -10,7 +10,7 @@ type ReportPagination struct {
 // org report types
 
 type OrgReportRecord struct {
-	RecordId        string         `json:"record_id"`
+	Id              string         `json:"id"`
 	ReportId        string         `json:"report_id"`
 	OrgId           uuid.UUID      `json:"org_id"`
 	Name            string         `json:"name"`
@@ -37,7 +37,7 @@ type UserOrgMembershipForReport struct {
 }
 
 type UserReportRecord struct {
-	RecordId        string                       `json:"record_id"`
+	Id              string                       `json:"id"`
 	ReportId        string                       `json:"report_id"`
 	UserId          uuid.UUID                    `json:"user_id"`
 	Email           string                       `json:"email"`
@@ -58,13 +58,3 @@ type UserReport struct {
 	HasMoreResults bool               `json:"has_more_results"`
 	ReportTime     int64              `json:"report_time"`
 }
-
-// report interval options
-
-const WEEKLY = "Weekly"
-const MONTHLY = "Monthly"
-const SEVEN_DAYS = "7"
-const FOURTEEN_DAYS = "14"
-const THIRTY_DAYS = "30"
-const SIXTY_DAYS = "60"
-const NINETY_DAYS = "90"

--- a/pkg/models/report.go
+++ b/pkg/models/report.go
@@ -1,0 +1,70 @@
+package models
+
+import "github.com/google/uuid"
+
+type ReportPagination struct {
+	PageSize   *int
+	PageNumber *int
+}
+
+// org report types
+
+type OrgReportRecord struct {
+	RecordId        string         `json:"record_id"`
+	ReportId        string         `json:"report_id"`
+	OrgId           uuid.UUID      `json:"org_id"`
+	Name            string         `json:"name"`
+	NumUsers        int            `json:"num_users"`
+	OrgCreatedAt    int64          `json:"org_created_at"`
+	ExtraProperties map[string]any `json:"extra_properties"`
+}
+
+type OrgReport struct {
+	OrgReports     []OrgReportRecord `json:"org_reports"`
+	CurrentPage    int               `json:"current_page"`
+	TotalCount     int               `json:"total_count"`
+	PageSize       int               `json:"page_size"`
+	HasMoreResults bool              `json:"has_more_results"`
+	ReportTime     int               `json:"report_time"`
+}
+
+// user report types
+
+type UserOrgMembershipForReport struct {
+	DisplayName string    `json:"display_name"`
+	OrgId       uuid.UUID `json:"org_id"`
+	UserRole    string    `json:"user_role"`
+}
+
+type UserReportRecord struct {
+	RecordId        string                       `json:"record_id"`
+	ReportId        string                       `json:"report_id"`
+	UserId          uuid.UUID                    `json:"user_id"`
+	Email           string                       `json:"email"`
+	UserCreatedAt   int64                        `json:"user_created_at"`
+	LastActiveAt    int64                        `json:"last_active_at"`
+	Username        *string                      `json:"username"`
+	FirstName       *string                      `json:"first_name"`
+	LastName        *string                      `json:"last_name"`
+	OrgData         []UserOrgMembershipForReport `json:"org_data"`
+	ExtraProperties map[string]any               `json:"extra_properties"`
+}
+
+type UserReport struct {
+	UserReports    []UserReportRecord `json:"user_reports"`
+	CurrentPage    int                `json:"current_page"`
+	TotalCount     int                `json:"total_count"`
+	PageSize       int                `json:"page_size"`
+	HasMoreResults bool               `json:"has_more_results"`
+	ReportTime     int64              `json:"report_time"`
+}
+
+// report interval options
+
+const WEEKLY = "Weekly"
+const MONTHLY = "Monthly"
+const SEVEN_DAYS = "7"
+const FOURTEEN_DAYS = "14"
+const THIRTY_DAYS = "30"
+const SIXTY_DAYS = "60"
+const NINETY_DAYS = "90"

--- a/pkg/models/user_insights.go
+++ b/pkg/models/user_insights.go
@@ -58,3 +58,22 @@ type UserReport struct {
 	HasMoreResults bool               `json:"has_more_results"`
 	ReportTime     int64              `json:"report_time"`
 }
+
+// chart data types
+
+type ChartDataPoint struct {
+	Result           int64  `json:"result"`
+	Date             string `json:"date"`
+	CadenceCompleted bool   `json:"cadence_completed"`
+}
+
+type ChartData struct {
+	Metrics   []ChartDataPoint `json:"metrics"`
+	Cadence   string           `json:"cadence"`
+	ChartType string           `json:"chart_type"`
+}
+
+type ChartRange struct {
+	StartDate *string
+	EndDate   *string
+}


### PR DESCRIPTION
## Tests
tested with an example app and the code below used at startup

## After PR
You can now do any of the following...
```go
thirtyDays := "30"
weekly := "Weekly"
sevenDays := "7"
daily := "Daily"
ten := 10
zero := 0

userReport, _ := client.FetchUserTopInviterReport(
	&thirtyDays, // 30 days
	&models.ReportPagination {
		PageSize: &ten, // defaults to 10 for all reports
		PageNumber: &zero, // defaults to 0 for all reports
	},
)

fmt.Println("Fetched User Top Inviter Report", userReport)

userReport, _ = client.FetchUserChampionReport(&thirtyDays, &models.ReportPagination {})

fmt.Println("Fetched User Champion Report", userReport)

userReport, _ = client.FetchUserReengagementReport(&weekly, &models.ReportPagination {})

fmt.Println("Fetched User Reengagement Report", userReport)

userReport, _ = client.FetchUserChurnReport(&sevenDays, &models.ReportPagination {})

fmt.Println("Fetched User Churn Report", userReport)

orgReport, _ := client.FetchOrgReengagementReport(&weekly, &models.ReportPagination {})

fmt.Println("Fetched Org Reengagement Report", orgReport)

orgReport, _ = client.FetchOrgChurnReport(&sevenDays, &models.ReportPagination {})

fmt.Println("Fetched Org Churn Report", orgReport)

orgReport, _ = client.FetchOrgGrowthReport(&thirtyDays, &models.ReportPagination {})

fmt.Println("Fetched Org Growth Report", orgReport)

orgReport, _ = client.FetchOrgAttritionReport(&thirtyDays, &models.ReportPagination {})

fmt.Println("Fetched Org Attrition Report", orgReport)

startDate := "2026-01-01"
timeseriesOfDailySignups, _ := client.FetchChartMetricData(
	"signups",
	&daily, // defaults to Daily if none provided
	&models.ChartRange {
		StartDate: &startDate, // YYYY-MM-DD format, defaults to 30 days ago
		// EndDate defaults to today yesterday is the most recent data
	},
)

fmt.Println("Fetched timeseries of daily signups", timeseriesOfDailySignups)
```